### PR TITLE
Adding Latest Debugger and Profiler dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@google-cloud/debug-agent": "^2.3.2",
-    "@google-cloud/profiler": "^0.1.14",
+    "@google-cloud/debug-agent": "^2.6.0",
+    "@google-cloud/profiler": "^0.2.0",
     "async": "^1.5.2",
     "body-parser": "^1.15.1",
     "connect-redis": "^3.2.0",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,8 @@
    require('@google-cloud/debug-agent').start({
-     serviceContext: {
+     allowExpressions: true,
+	 serviceContext: {
 	    service: 'front-end',
-	    version: 'VERSION'
+	    version: '1.0.0'
 	  }
 	})
   , require('@google-cloud/profiler').start({


### PR DESCRIPTION
The Stackdriver Debugger and Profiler Agents for Microservices Demo (mtwo/microservices-demo) did not work for me until I updated them to latest version. To map the source code it was easier to give version "1.0.0" than VERSION.